### PR TITLE
Connect to SQL Server Python

### DIFF
--- a/database/sqlserver-conn.py
+++ b/database/sqlserver-conn.py
@@ -1,0 +1,14 @@
+import pyodbc
+conn_properties = {
+    'server': 'oskrvpydb.mssql.somee.com',
+    'user': 'oscarvalles_SQLLogin_1',
+    'password': 'qg4umuntt6',
+    'db': 'oskrvpydb',
+    'driver': '{/usr/local/Cellar/msodbcsql17/17.9.1.1/lib/libmsodbcsql.17.dylib}'
+}
+conn = pyodbc.connect(**conn_properties)
+query = "select * from Persons"
+cursor = conn.cursor()
+cursor.execute(query)
+for r in cursor:
+    print(r)

--- a/database/sqlserver-conn.py
+++ b/database/sqlserver-conn.py
@@ -1,9 +1,19 @@
+'''
+Two important things to do when looking to use pyodbc
+This assumes you have homebrew installed (https://brew.sh)
+1.) brew install unixodbc
+2.) brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
+brew update
+HOMEBREW_NO_ENV_FILTERING=1 ACCEPT_EULA=Y brew install msodbcsql17 mssql-tools
+'''
+
 import pyodbc
+import os
 conn_properties = {
-    'server': 'oskrvpydb.mssql.somee.com',
-    'user': 'oscarvalles_SQLLogin_1',
-    'password': 'qg4umuntt6',
-    'db': 'oskrvpydb',
+    'server': os.getenv('SQL_SERVER_HOST'),
+    'user': os.getenv('SQL_SERVER_LOGIN'),
+    'password': os.getenv('SQL_SERVER_PASS'),
+    'db': os.getenv('SQL_SERVER_DB'),
     'driver': '{/usr/local/Cellar/msodbcsql17/17.9.1.1/lib/libmsodbcsql.17.dylib}'
 }
 conn = pyodbc.connect(**conn_properties)
@@ -12,3 +22,5 @@ cursor = conn.cursor()
 cursor.execute(query)
 for r in cursor:
     print(r)
+
+


### PR DESCRIPTION
In order to connect to Microsoft's SQL Server using Python on MacOSX the following is recommended.

'''
Two important things to do when looking to use pyodbc
This assumes you have homebrew installed (https://brew.sh)
1.) brew install unixodbc
2.) brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
brew update
HOMEBREW_NO_ENV_FILTERING=1 ACCEPT_EULA=Y brew install msodbcsql17 mssql-tools
'''

Lastly, you will need to look for a specific driver file. Mine ended up being installed in a location noted in the script file. That full path will be replacing the `{DRIVER}` parameter.